### PR TITLE
Fix bishop and rook initial positions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -445,7 +444,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -469,7 +467,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1433,7 +1430,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1747,7 +1743,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2972,7 +2967,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -3503,7 +3497,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3516,7 +3509,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4102,7 +4094,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/utils/initialBoard.test.ts
+++ b/src/utils/initialBoard.test.ts
@@ -29,28 +29,28 @@ describe('createInitialBoard', () => {
   })
 
   it('should place sente rook at correct position', () => {
-    const rook = board[7][1]
+    const rook = board[7][7]
     expect(rook).not.toBeNull()
     expect(rook?.type).toBe('rook')
     expect(rook?.player).toBe('sente')
   })
 
   it('should place gote rook at correct position', () => {
-    const rook = board[1][7]
+    const rook = board[1][1]
     expect(rook).not.toBeNull()
     expect(rook?.type).toBe('rook')
     expect(rook?.player).toBe('gote')
   })
 
   it('should place sente bishop at correct position', () => {
-    const bishop = board[7][7]
+    const bishop = board[7][1]
     expect(bishop).not.toBeNull()
     expect(bishop?.type).toBe('bishop')
     expect(bishop?.player).toBe('sente')
   })
 
   it('should place gote bishop at correct position', () => {
-    const bishop = board[1][1]
+    const bishop = board[1][7]
     expect(bishop).not.toBeNull()
     expect(bishop?.type).toBe('bishop')
     expect(bishop?.player).toBe('gote')

--- a/src/utils/initialBoard.ts
+++ b/src/utils/initialBoard.ts
@@ -19,8 +19,8 @@ export function createInitialBoard(): Board {
   })
 
   // 後手の飛車と角
-  board[1][7] = createPiece('rook', 'gote')
-  board[1][1] = createPiece('bishop', 'gote')
+  board[1][1] = createPiece('rook', 'gote')
+  board[1][7] = createPiece('bishop', 'gote')
 
   // 後手の歩
   for (let col = 0; col < 9; col++) {
@@ -34,8 +34,8 @@ export function createInitialBoard(): Board {
   })
 
   // 先手の飛車と角
-  board[7][1] = createPiece('rook', 'sente')
-  board[7][7] = createPiece('bishop', 'sente')
+  board[7][7] = createPiece('rook', 'sente')
+  board[7][1] = createPiece('bishop', 'sente')
 
   // 先手の歩
   for (let col = 0; col < 9; col++) {


### PR DESCRIPTION
将棋の正しいルールに従って、角行と飛車の初期位置を修正しました。

修正内容:
- 飛車: 2筋（col 1）に配置
- 角行: 8筋（col 7）に配置

変更ファイル:
- src/utils/initialBoard.ts: 駒の初期配置を修正
- src/utils/initialBoard.test.ts: テストケースを正しい位置に更新