### PR TITLE
Fix GitHub issue #2 in shogi-web1

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -23,9 +23,9 @@ const pieceToJapanese: Record<string, string> = {
 // 成り駒の表記
 const promotedPieceToJapanese: Record<string, string> = {
   pawn: 'と',
-  lance: '成香',
-  knight: '成桂',
-  silver: '成銀',
+  lance: '杏',
+  knight: '圭',
+  silver: '全',
   bishop: '馬',
   rook: '竜',
 }


### PR DESCRIPTION
銀、桂、香の成り駒が2文字表記でマスからはみ出す問題を修正。
以下の1文字表記に変更:
- 成香 → 杏
- 成桂 → 圭
- 成銀 → 全

Fixes #2