### PR TITLE
ピンの検出とチェック対応の移動フィルタリングを実装

### DIFF
--- a/src/utils/checkmate.ts
+++ b/src/utils/checkmate.ts
@@ -52,20 +52,22 @@ function wouldBeInCheck(board: Board, from: Position, to: Position, player: Play
   return isInCheck(newBoard, player)
 }
 
-// 合法手を返す（王将のみ王手回避フィルタを適用、他の駒はそのまま）
+// 合法手を返す（全ての駒について、移動後に自玉が王手にならない手のみ返す）
 export function getLegalMoves(board: Board, from: Position): Position[] {
   const piece = board[from.row][from.col]
   if (!piece) return []
   const moves = getValidMoves(board, from)
-  if (piece.type === 'king') {
-    return moves.filter(to => !wouldBeInCheck(board, from, to, piece.player))
-  }
-  return moves
+  return moves.filter(to => !wouldBeInCheck(board, from, to, piece.player))
 }
 
-// 持ち駒の打ち込み先を返す（打ち込みルールのみ適用）
+// 持ち駒の打ち込み先を返す（打ち込みルール＋王手回避フィルタを適用）
 export function getLegalDropPositions(board: Board, pieceType: CapturablePieceType, player: Player): Position[] {
-  return getDropPositions(board, pieceType, player)
+  const positions = getDropPositions(board, pieceType, player)
+  return positions.filter(to => {
+    const newBoard = board.map(row => [...row])
+    newBoard[to.row][to.col] = { type: pieceType, player, isPromoted: false }
+    return !isInCheck(newBoard, player)
+  })
 }
 
 // 移動後に王手が解消されるか判定（詰み判定用）


### PR DESCRIPTION
## 概要
このPRは、将棋の指し手検証ロジックにおいて、適切なピン検出とチェック対応の移動フィルタリングを実装します。以前は、玉の移動のみがチェックに入らないようにフィルタリングされていましたが、他の駒はピンされていても自由に動けてしまっていました。現在は、すべての駒が適切に検証され、玉を王手にさらさないことを保証し、玉が王手されている時は指し手と駒打ちがフィルタリングされます。

## 主な変更点
* すべての駒のピン検出: getLegalMoves()を修正し、すべての駒タイプ(玉だけでなく)をフィルタリングして、玉を王手にさらす移動を防止します。これにより、ピンされた駒は攻撃ラインに沿ってのみ移動できる、適切なピン検出を実装しています。
* チェック対応の駒打ちフィルタリング: getLegalDropPositions()を更新し、王手を解消するかどうかに基づいて駒打ちをフィルタリングします。玉が王手されている時は、攻撃を遮断するか玉が逃げられるようにする駒打ちのみが許可されます。
* テスト期待値の更新:
   * ピンされた駒が攻撃を遮断する移動のみ可能であることを検証するようにテスト期待値を変更
   * 王手を解消する移動の新しいテストケースを追加
   * 王手を解消する駒打ちの新しいテストケースを追加
   * テストされている実際の動作を反映するようにテストの説明を明確化

## 実装の詳細
* getLegalMoves()は、玉だけでなくすべての駒タイプにwouldBeInCheck()フィルタリングを適用するようになりました
* getLegalDropPositions()は、各潜在的な駒打ちをシミュレートし、移動後にプレイヤーの玉が王手されたままにならないことを検証します
* フィルタリングロジックは、移動/駒打ち後にプレイヤーの玉が王手されない場合のみ、その移動/駒打ちが合法であることを保証します

https://claude.ai/code/session_01SMmGVkeogwWcGNLXghscZk