### PR TITLE
feat: 持ち駒と手番表示のレイアウトを改善

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,7 +14,7 @@ h1 {
 }
 
 .game-info {
-  margin-bottom: 1.5rem;
+  grid-area: info;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -44,6 +44,7 @@ h1 {
 }
 
 .reset-button {
+  margin-bottom: 1.5rem;
   padding: 0.75rem 1.5rem;
   font-size: 1rem;
   font-weight: bold;
@@ -64,8 +65,25 @@ h1 {
 }
 
 .game-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1.5rem;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-template-rows: auto auto;
+  grid-template-areas:
+    "gote  board sente"
+    ".     info  .";
+  gap: 0.5rem;
+}
+
+.game-container .board {
+  grid-area: board;
+}
+
+.game-container .captured-pieces.gote {
+  grid-area: gote;
+  align-self: start;
+}
+
+.game-container .captured-pieces.sente {
+  grid-area: sente;
+  align-self: end;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,21 +23,9 @@ function App() {
     <div className="app">
       <h1>将棋</h1>
 
-      <div className="game-info">
-        {isGameOver ? (
-          <p className="game-over">
-            🎉 {winner === 'sente' ? '先手' : '後手'}の勝ちです！
-          </p>
-        ) : (
-          <p className="turn-indicator">
-            {currentPlayer === 'sente' ? '▲ 先手の番です' : '△ 後手の番です'}
-            {inCheck && <span className="check-indicator"> - 王手！</span>}
-          </p>
-        )}
-        <button onClick={resetGame} className="reset-button">
-          新しいゲーム
-        </button>
-      </div>
+      <button onClick={resetGame} className="reset-button">
+        新しいゲーム
+      </button>
 
       <div className="game-container">
         <CapturedPieces
@@ -60,6 +48,19 @@ function App() {
           onPieceClick={selectDropPiece}
           isCurrentPlayer={currentPlayer === 'sente'}
         />
+
+        <div className="game-info">
+          {isGameOver ? (
+            <p className="game-over">
+              🎉 {winner === 'sente' ? '先手' : '後手'}の勝ちです！
+            </p>
+          ) : (
+            <p className="turn-indicator">
+              {currentPlayer === 'sente' ? '▲ 先手の番です' : '△ 後手の番です'}
+              {inCheck && <span className="check-indicator"> - 王手！</span>}
+            </p>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/components/CapturedPieces.css
+++ b/src/components/CapturedPieces.css
@@ -1,32 +1,32 @@
 .captured-pieces {
-  margin: 1rem 0;
-  padding: 1rem;
+  padding: 0.75rem;
   background-color: #f5f5f5;
   border-radius: 8px;
-  min-width: 300px;
+  max-width: 120px;
 }
 
 .captured-pieces h3 {
-  font-size: 1.2rem;
-  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
   color: #333;
+  white-space: nowrap;
 }
 
 .pieces-container {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .captured-piece {
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.5rem 0.75rem;
+  padding: 0.25rem 0.5rem;
   background-color: #fff;
   border: 2px solid #ddd;
   border-radius: 4px;
-  font-size: 1.25rem;
+  font-size: 1.1rem;
   font-weight: bold;
 }
 


### PR DESCRIPTION
持ち駒を将棋盤の横に配置し、手番表示を盤の直下に移動。
- 後手の持ち駒: 盤の左上
- 先手の持ち駒: 盤の右下（下揃え）
- 手番表示: 盤の直下（視認性向上）
- game-containerをCSS Gridレイアウトに変更