### PR TITLE
fix: GitHub Pages デプロイの競合状態を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     concurrency:
-      group: pages-deploy-main
-      cancel-in-progress: true
+      group: pages-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,8 +50,8 @@ jobs:
     if: github.event_name == 'push' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     concurrency:
-      group: pages-deploy-${{ github.ref_name }}
-      cancel-in-progress: true
+      group: pages-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,6 +91,9 @@ jobs:
   cleanup-branch:
     if: github.event_name == 'delete'
     runs-on: ubuntu-latest
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout gh-pages branch
         uses: actions/checkout@v4


### PR DESCRIPTION
## 概要
Issue #11 で報告されていた、PRマージ時にGitHub Pagesのmainブランチが更新されない問題を修正します。

## 問題の原因
PRマージ時に`deploy-main`と`cleanup-branch`ジョブが並行実行され、gh-pagesブランチへのgit pushで競合が発生していました。

具体的には：
1. PRがmainにマージされると、`push`イベントと`delete`イベントが同時に発生
2. `deploy-main`がgh-pagesを特定のコミット時点でクローン
3. その間に`cleanup-branch`が先にプッシュしてgh-pagesを更新
4. `deploy-main`が後からプッシュしようとして、期待していたコミットと異なるため失敗

エラーログ：
```
! [remote rejected] gh-pages -> gh-pages (cannot lock ref 'refs/heads/gh-pages': 
is at d195551... but expected 3ec10ab...)
```

## 解決策
すべてのgh-pagesへのデプロイ操作を同じconcurrencyグループに統一し、順次実行させることで競合を回避します。

### 変更内容
- **deploy-main**: `group: pages-deploy-main` → `pages-deploy`、`cancel-in-progress: true` → `false`
- **deploy-branch**: `group: pages-deploy-{branch}` → `pages-deploy`、`cancel-in-progress: true` → `false`
- **cleanup-branch**: concurrency設定を新規追加（`group: pages-deploy`、`cancel-in-progress: false`）

## テスト計画
1. このPRをmainにマージ（ブランチ削除オプション有効）
2. GitHub Actionsで`deploy-main`と`cleanup-branch`が順次実行されることを確認
3. 両方のジョブが成功することを確認
4. https://akiyoshi83.github.io/shogi-web1/ で最新の内容が表示されることを確認

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)